### PR TITLE
Extend IInspect onto cljs.core.UUID

### DIFF
--- a/src/ankha/core.cljs
+++ b/src/ankha/core.cljs
@@ -297,6 +297,9 @@
   Range
   (-inspect [this] (coll-view this "(" ")" "seq range"))
 
+  UUID
+  (-inspect [this] (literal "uuid" this))
+
   om/IndexedCursor
   (-inspect [this]
     (coll-view this "[" "]" "vector indexed-cursor"))


### PR DESCRIPTION
I assume you're open to new inspector implementations. I needed one for UUID, and since it's part of cljs.core, I thought the inspector might belong in ankha proper.
