### PR TITLE
Fix problem parsing non-sequable date-time (goog.date.UtcDateTime).

### DIFF
--- a/src/ankha/core.cljs
+++ b/src/ankha/core.cljs
@@ -53,7 +53,10 @@
   [x]
   (if (object? x)
     (object/isEmpty x)
-    (clojure.core/empty? x)))
+    (try 
+      (clojure.core/empty? x)
+      (catch js/Error _
+        true))))
 
 (defn- record?
   "Return true if x satisfies IRecord, false otherwise."


### PR DESCRIPTION
When `inspect`ed cursor contains a UtcDateTime object, call to `empty?` throws an exception. This is a quick workaround for this.